### PR TITLE
Add rabby-wallet-hub job to CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 executors:
   my-custom-executor:
     docker:
@@ -8,6 +9,7 @@ executors:
           # visit app.circleci.com/settings/project/github/Dargon789/Rabby/environment-variables
           username: $DOCKER_HUB_USER
           password: $DOCKER_HUB_PASSWORD
+          
 jobs:
   my-job-name:
 
@@ -20,4 +22,4 @@ jobs:
 workflows:
   my-custom-workflow:
     jobs:
-      - my-job-name
+       - rabby-wallet-hub


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Configure the custom CircleCI workflow to use the rabby-wallet-hub job.